### PR TITLE
feat: offer partial hashes in the database format specifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,20 +88,20 @@ For applications with a large number of tenants, it may be preferable to use a "
 For the purposes of creating nesteed directories, the following format specifiers are available (in addition to `tenant`:
 
 - `tenant_hash1` - first two hexadecimal characters of the MD5 signature of the tenant
-- `tenant_hash2` - next two characters
-- `tenant_hash3` - next two characters
-- `tenant_hash4` - next two characters
+- `tenant_hash2` - next two characters as a subdirectory of hash1
+- `tenant_hash3` - next two characters as a subdirectory of hash2
+- `tenant_hash4` - next two characters as a subdirectory of hash3
 
 So, for example, for a tenant of `foo` which hashes to `acbd18db4cc2f85cedef654fccc4a4d8`:
 
 - `tenant_hash1` = `ac`
-- `tenant_hash2` = `bd`
-- `tenant_hash3` = `18`
-- `tenant_hash4` = `db`
+- `tenant_hash2` = `ac/bd`
+- `tenant_hash3` = `ac/bd/18`
+- `tenant_hash4` = `ac/bd/18/db`
 
 And so for a database config of:
 
-> `storage/%{tenant_hash1}/%{tenant_hash2}/%{tenant_hash3}/%{tenant_hash4}/%{tenant}.sqlite3`
+> `storage/%{tenant_hash4}/%{tenant}.sqlite3`
 
 the application could have 4.2 billion tenants without exceeding 255 entries in any directory.
 

--- a/lib/active_record/tenanted.rb
+++ b/lib/active_record/tenanted.rb
@@ -48,13 +48,13 @@ module ActiveRecord
         tenant_shard = current_shard
         tenant_name = "#{tenant_config_name}_#{tenant_shard}"
 
-        tenant_hash = Digest::MD5.hexdigest(tenant_shard.to_s)
+        tenant_hash = Digest::MD5.hexdigest(tenant_shard.to_s).chars.each_slice(2).take(4).map(&:join)
         format_specifiers = {
           tenant: tenant_shard,
-          tenant_hash1: tenant_hash[0..1], # 255
-          tenant_hash2: tenant_hash[2..3], # x 255 = 64 thousand
-          tenant_hash3: tenant_hash[4..5], # x 255 = 16 million
-          tenant_hash4: tenant_hash[6..7]  # x 255 = 4.2 billion
+          tenant_hash1: tenant_hash[0], # 255
+          tenant_hash2: File.join(tenant_hash[0..1]), # x 255 = 64 thousand
+          tenant_hash3: File.join(tenant_hash[0..2]), # x 255 = 16 million
+          tenant_hash4: File.join(tenant_hash[0..3])  # x 255 = 4.2 billion
         }
 
         config_hash = base_config.configuration_hash.dup

--- a/test/active_record/test_tenanted.rb
+++ b/test/active_record/test_tenanted.rb
@@ -21,7 +21,7 @@ class ActiveRecord::TestTenanted < ActiveRecord::Tenanted::TestCase
       secondary: {
         tenanted: true,
         adapter: "sqlite3",
-        database: "tmp/storage/%{tenant_hash1}/%{tenant_hash2}/%{tenant_hash3}/%{tenant_hash4}/secondary-%{tenant}.sqlite3",
+        database: "tmp/storage/%{tenant_hash4}/secondary-%{tenant}.sqlite3",
         migrations_paths: "test/fixtures/migrations",
       }
     }


### PR DESCRIPTION
Allow for a large number of tenants without any directory being particularly full.

For a tenant of `foo` which hashes to `acbd18db4cc2f85cedef654fccc4a4d8`:

- `tenant_hash1` = `ac`
- `tenant_hash2` = `ac/bd`
- `tenant_hash3` = `ac/bd/18`
- `tenant_hash4` = `ac/bd/18/db`

For example, a database.yml containing:

```
  database: "storage/%{tenant_hash4}/%{tenant}.sqlite3"
```

would be evaluated as:

```
storage/ac/bd/18/db/foo.sqlite3
```
