### PR TITLE
fix: initializers to extend testing frameworks only run in test env

### DIFF
--- a/lib/active_record/tenanted/railtie.rb
+++ b/lib/active_record/tenanted/railtie.rb
@@ -105,30 +105,32 @@ module ActiveRecord
           end
         end
 
-        ActiveSupport.on_load(:active_support_test_case) do
-          include ActiveRecord::Tenanted::Testing::ActiveSupportTestCase
-        end
+        if Rails.env.test?
+          ActiveSupport.on_load(:active_support_test_case) do
+            include ActiveRecord::Tenanted::Testing::ActiveSupportTestCase
+          end
 
-        ActiveSupport.on_load(:action_dispatch_integration_test) do
-          include ActiveRecord::Tenanted::Testing::ActionDispatchIntegrationTest
+          ActiveSupport.on_load(:action_dispatch_integration_test) do
+            include ActiveRecord::Tenanted::Testing::ActionDispatchIntegrationTest
 
-          ActionDispatch::Integration::Session.prepend ActiveRecord::Tenanted::Testing::ActionDispatchIntegrationSession
-        end
+            ActionDispatch::Integration::Session.prepend ActiveRecord::Tenanted::Testing::ActionDispatchIntegrationSession
+          end
 
-        ActiveSupport.on_load(:action_dispatch_system_test_case) do
-          include ActiveRecord::Tenanted::Testing::ActionDispatchSystemTestCase
-        end
+          ActiveSupport.on_load(:action_dispatch_system_test_case) do
+            include ActiveRecord::Tenanted::Testing::ActionDispatchSystemTestCase
+          end
 
-        ActiveSupport.on_load(:active_record_fixtures) do
-          include ActiveRecord::Tenanted::Testing::ActiveRecordFixtures
-        end
+          ActiveSupport.on_load(:active_record_fixtures) do
+            include ActiveRecord::Tenanted::Testing::ActiveRecordFixtures
+          end
 
-        ActiveSupport.on_load(:active_job_test_case) do
-          include ActiveRecord::Tenanted::Testing::ActiveJobTestCase
-        end
+          ActiveSupport.on_load(:active_job_test_case) do
+            include ActiveRecord::Tenanted::Testing::ActiveJobTestCase
+          end
 
-        ActiveSupport.on_load(:action_cable_connection_test_case) do
-          include ActiveRecord::Tenanted::Testing::ActionCableTestCase
+          ActiveSupport.on_load(:action_cable_connection_test_case) do
+            include ActiveRecord::Tenanted::Testing::ActionCableTestCase
+          end
         end
       end
 


### PR DESCRIPTION
If `app` is called in the console, then the Rails console helper will load ActionDispatch::Integration::Session to provide URL helpers. That class loads ActiveSupport::TestCase which will trigger our active_support_test_case load hook, which will set a current_tenant to prepare for fixture loading.

Because we only want to set that tenant to prepare for fixture loading, we should only set up that hook in a test environment. But more broadly, we really don't need any of our test-framework load hooks to be invoked unless we're actually testing.
