### PR TITLE
Simplify the gem's use of concerns

### DIFF
--- a/lib/active_record/tenanted/base.rb
+++ b/lib/active_record/tenanted/base.rb
@@ -17,7 +17,7 @@ module ActiveRecord
           raise Error, "Class #{self} is already tenanted" if tenanted?
           raise Error, "Class #{self} is not an abstract connection class" unless abstract_class?
 
-          include Tenant
+          prepend Tenant
 
           self.connection_class = true
           @tenanted_config_name = config_name
@@ -28,7 +28,7 @@ module ActiveRecord
         end
 
         def subtenant_of(class_name)
-          include Subtenant
+          prepend Subtenant
 
           @tenanted_subtenant_of = class_name
         end

--- a/lib/active_record/tenanted/global_id.rb
+++ b/lib/active_record/tenanted/global_id.rb
@@ -5,12 +5,8 @@ require "globalid"
 module ActiveRecord
   module Tenanted
     module GlobalId
-      extend ActiveSupport::Concern
-
-      included do
-        def tenant
-          params && params[:tenant]
-        end
+      def tenant
+        params && params[:tenant]
       end
 
       class Locator

--- a/lib/active_record/tenanted/patches.rb
+++ b/lib/active_record/tenanted/patches.rb
@@ -6,23 +6,19 @@ module ActiveRecord
       # TODO: I think this is needed because there was no followup to rails/rails#46270.
       # See rails/rails@901828f2 from that PR for background.
       module DatabaseTasks
-        extend ActiveSupport::Concern
+        private def with_temporary_pool(db_config, clobber: false)
+          original_db_config = begin
+            migration_class.connection_db_config
+          rescue ActiveRecord::ConnectionNotDefined
+            nil
+          end
 
-        included do
-          private def with_temporary_pool(db_config, clobber: false)
-            original_db_config = begin
-              migration_class.connection_db_config
-            rescue ActiveRecord::ConnectionNotDefined
-              nil
-            end
+          begin
+            pool = migration_class.connection_handler.establish_connection(db_config, clobber: clobber)
 
-            begin
-              pool = migration_class.connection_handler.establish_connection(db_config, clobber: clobber)
-
-              yield pool
-            ensure
-              migration_class.connection_handler.establish_connection(original_db_config, clobber: clobber) if original_db_config
-            end
+            yield pool
+          ensure
+            migration_class.connection_handler.establish_connection(original_db_config, clobber: clobber) if original_db_config
           end
         end
       end

--- a/lib/active_record/tenanted/railtie.rb
+++ b/lib/active_record/tenanted/railtie.rb
@@ -32,13 +32,7 @@ module ActiveRecord
 
       initializer "active_record_tenanted.active_record_base" do
         ActiveSupport.on_load(:active_record) do
-          include ActiveRecord::Tenanted::Base
-        end
-      end
-
-      initializer "active_record_tenanted.action_cable_connection" do
-        ActiveSupport.on_load(:action_cable_connection) do
-          include ActiveRecord::Tenanted::CableConnection::Base
+          prepend ActiveRecord::Tenanted::Base
         end
       end
 
@@ -59,19 +53,25 @@ module ActiveRecord
 
       initializer "active_record-tenanted.monkey_patches" do
         ActiveSupport.on_load(:active_record) do
-          ActiveRecord::Tasks::DatabaseTasks.include ActiveRecord::Tenanted::Patches::DatabaseTasks
-          ActiveRecord::Base.include ActiveRecord::Tenanted::Patches::Attributes
+          prepend ActiveRecord::Tenanted::Patches::Attributes
+          ActiveRecord::Tasks::DatabaseTasks.prepend ActiveRecord::Tenanted::Patches::DatabaseTasks
         end
       end
 
       initializer "active_record-tenanted.active_job" do
         ActiveSupport.on_load(:active_job) do
-          include ActiveRecord::Tenanted::Job
+          prepend ActiveRecord::Tenanted::Job
+        end
+      end
+
+      initializer "active_record_tenanted.action_cable_connection" do
+        ActiveSupport.on_load(:action_cable_connection) do
+          prepend ActiveRecord::Tenanted::CableConnection::Base
         end
       end
 
       initializer "active_record-tenanted.global_id", after: "global_id" do
-        ::GlobalID.include ActiveRecord::Tenanted::GlobalId
+        ::GlobalID.prepend ActiveRecord::Tenanted::GlobalId
         ::GlobalID::Locator.use GlobalID.app, ActiveRecord::Tenanted::GlobalId::Locator.new
       end
 
@@ -80,7 +80,7 @@ module ActiveRecord
         # module into the class before the service is initialized.
         # As a workaround, explicitly require this file.
         require "active_storage/service/disk_service"
-        ActiveStorage::Service::DiskService.include ActiveRecord::Tenanted::StorageService
+        ActiveStorage::Service::DiskService.prepend ActiveRecord::Tenanted::StorageService
       end
 
       config.after_initialize do
@@ -107,29 +107,28 @@ module ActiveRecord
 
         if Rails.env.test?
           ActiveSupport.on_load(:active_support_test_case) do
-            include ActiveRecord::Tenanted::Testing::ActiveSupportTestCase
+            prepend ActiveRecord::Tenanted::Testing::ActiveSupportTestCase
           end
 
           ActiveSupport.on_load(:action_dispatch_integration_test) do
-            include ActiveRecord::Tenanted::Testing::ActionDispatchIntegrationTest
-
+            prepend ActiveRecord::Tenanted::Testing::ActionDispatchIntegrationTest
             ActionDispatch::Integration::Session.prepend ActiveRecord::Tenanted::Testing::ActionDispatchIntegrationSession
           end
 
           ActiveSupport.on_load(:action_dispatch_system_test_case) do
-            include ActiveRecord::Tenanted::Testing::ActionDispatchSystemTestCase
+            prepend ActiveRecord::Tenanted::Testing::ActionDispatchSystemTestCase
           end
 
           ActiveSupport.on_load(:active_record_fixtures) do
-            include ActiveRecord::Tenanted::Testing::ActiveRecordFixtures
+            prepend ActiveRecord::Tenanted::Testing::ActiveRecordFixtures
           end
 
           ActiveSupport.on_load(:active_job_test_case) do
-            include ActiveRecord::Tenanted::Testing::ActiveJobTestCase
+            prepend ActiveRecord::Tenanted::Testing::ActiveJobTestCase
           end
 
           ActiveSupport.on_load(:action_cable_connection_test_case) do
-            include ActiveRecord::Tenanted::Testing::ActionCableTestCase
+            prepend ActiveRecord::Tenanted::Testing::ActionCableTestCase
           end
         end
       end

--- a/lib/active_record/tenanted/storage_service.rb
+++ b/lib/active_record/tenanted/storage_service.rb
@@ -3,33 +3,29 @@
 module ActiveRecord
   module Tenanted
     module StorageService # :nodoc:
-      extend ActiveSupport::Concern
+      def initialize(root:, public: false, tenanted: false, **options)
+        @root = root
+        @public = public
+        @tenanted = tenanted
+      end
 
-      included do
-        def initialize(root:, public: false, tenanted: false, **options)
-          @root = root
-          @public = public
-          @tenanted = tenanted
-        end
+      def tenanted?
+        @tenanted
+      end
 
-        def tenanted?
-          @tenanted
-        end
-
-        def root
-          if tenanted?
-            unless klass = ActiveRecord::Tenanted.connection_class
-              raise TenantConfigurationError, "Active Storage is tenanted, but no connection_class is configured"
-            end
-
-            unless tenant = klass.current_tenant
-              raise NoTenantError, "Cannot access ActiveStorage Disk service without a tenant"
-            end
-
-            @root % { tenant: tenant }
-          else
-            @root
+      def root
+        if tenanted?
+          unless klass = ActiveRecord::Tenanted.connection_class
+            raise TenantConfigurationError, "Active Storage is tenanted, but no connection_class is configured"
           end
+
+          unless tenant = klass.current_tenant
+            raise NoTenantError, "Cannot access ActiveStorage Disk service without a tenant"
+          end
+
+          @root % { tenant: tenant }
+        else
+          @root
         end
       end
     end

--- a/lib/active_record/tenanted/subtenant.rb
+++ b/lib/active_record/tenanted/subtenant.rb
@@ -5,10 +5,6 @@ module ActiveRecord
     module Subtenant
       extend ActiveSupport::Concern
 
-      included do
-        include TenantCommon
-      end
-
       class_methods do
         def tenanted?
           true
@@ -30,6 +26,10 @@ module ActiveRecord
         def connection_pool
           tenanted_with_class.connection_pool
         end
+      end
+
+      prepended do
+        prepend TenantCommon
       end
     end
   end


### PR DESCRIPTION
- Use prepend everywhere
- Only use ActiveSupport::Concern when it's needed
- Order the methods consistently in concerns
- Instance methods are never in an included/prepended block