### PR TITLE
Implement `#log` in the abstract connection adapter base class

### DIFF
--- a/lib/active_record/tenanted/connection_adapter.rb
+++ b/lib/active_record/tenanted/connection_adapter.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Tenanted
+    module ConnectionAdapter # :nodoc:
+      extend ActiveSupport::Concern
+
+      prepended do
+        attr_accessor :tenant
+      end
+
+      def log(sql, name = "SQL", binds = [], type_casted_binds = [], async: false, allow_retry: false, &block)
+        name = [ name, "[tenant=#{tenant}]" ].compact.join(" ") if tenanted?
+        super
+      end
+
+      def tenanted?
+        tenant.present?
+      end
+    end
+  end
+end

--- a/lib/active_record/tenanted/database_configurations.rb
+++ b/lib/active_record/tenanted/database_configurations.rb
@@ -55,20 +55,8 @@ module ActiveRecord
           configuration_hash.fetch(:tenant)
         end
 
-        def new_connection # :nodoc:
-          super.tap do |conn|
-            # Let's preserve the tenant name as a string literal in the log method for all tenanted
-            # connections at construction time, so that regardless of whether we're in a proper
-            # tenanted context we are able to log the tenant name when any tenanted connection is
-            # used.
-            #
-            # TODO: this could be upstreamed as a shard-related feature unrelated to tenanting.
-            conn.class_eval <<~CODE, __FILE__, __LINE__ + 1
-              private def log(sql, name = "SQL", *args, **kwargs, &block)
-                super(sql, "\#{name} [tenant=#{tenant}]", *args, **kwargs, &block)
-              end
-            CODE
-          end
+        def new_connection
+          super.tap { |conn| conn.tenant = tenant }
         end
 
         def tenanted_config_name

--- a/lib/active_record/tenanted/railtie.rb
+++ b/lib/active_record/tenanted/railtie.rb
@@ -113,6 +113,12 @@ module ActiveRecord
         ActiveStorage::Service::DiskService.prepend ActiveRecord::Tenanted::StorageService
       end
 
+      initializer "active_record-tenanted.active_record_connection_adapter" do
+        ActiveSupport.on_load(:active_record) do
+          ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ActiveRecord::Tenanted::ConnectionAdapter
+        end
+      end
+
       config.after_initialize do
         ActiveSupport.on_load(:action_mailbox_record) do
           if Rails.application.config.active_record_tenanted.connection_class.present? &&

--- a/test/unit/connection_adapter_test.rb
+++ b/test/unit/connection_adapter_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe ActiveRecord::Tenanted::ConnectionAdapter do
+  with_scenario(:primary_db, :primary_record) do
+    describe ".tenanted?" do
+      test "returns false for untenanted connection" do
+        assert_not(Announcement.connection.tenanted?)
+      end
+
+      test "returns true for tenanted connection" do
+        TenantedApplicationRecord.create_tenant("foo") do
+          assert_predicate(User.connection, :tenanted?)
+        end
+      end
+    end
+
+    describe ".tenant" do
+      test "returns nil for untenanted connection" do
+        assert_nil(Announcement.connection.tenant)
+      end
+
+      test "returns tenant name for tenanted connection" do
+        TenantedApplicationRecord.create_tenant("foo") do
+          assert_equal("foo", User.connection.tenant)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
to log the tenant on every database access. This is simpler and more expressive than the previous approach that implemented a singleton method on every tenanted connection instance.

Note that all connections now have a `tenant` attribute and will all respond to `tenanted?`.