### PR TITLE
Implement current_tenant= and with_tenant in concrete tenant classes

### DIFF
--- a/lib/active_record/tenanted/tenant.rb
+++ b/lib/active_record/tenanted/tenant.rb
@@ -68,7 +68,7 @@ module ActiveRecord
         def current_tenant=(tenant_name)
           tenant_name = tenant_name.to_s unless tenant_name == UNTENANTED_SENTINEL
 
-          connecting_to(shard: tenant_name, role: ActiveRecord.writing_role)
+          connection_class_for_self.connecting_to(shard: tenant_name, role: ActiveRecord.writing_role)
         end
 
         def tenant_exist?(tenant_name)
@@ -82,7 +82,7 @@ module ActiveRecord
           if tenant_name == current_tenant
             yield
           else
-            connected_to(shard: tenant_name, role: ActiveRecord.writing_role) do
+            connection_class_for_self.connected_to(shard: tenant_name, role: ActiveRecord.writing_role) do
               prohibit_shard_swapping(prohibit_shard_swapping) do
                 log_tenant_tag(tenant_name, &block)
               end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,10 +51,11 @@ module ActiveRecord
           super
         end
 
-        def for_each_scenario(s = all_scenarios, &block)
+        def for_each_scenario(s = all_scenarios, except: {}, &block)
           s.each do |db_scenario, model_scenarios|
             with_db_scenario(db_scenario) do
               model_scenarios.each do |model_scenario|
+                next if except[db_scenario.to_sym]&.include?(model_scenario.to_sym)
                 with_model_scenario(model_scenario, &block)
               end
             end


### PR DESCRIPTION
This allows console users to use

    User.current_tenant = "foo"

instead of the longer

    ApplicationRecord.current_tenant = "foo"

And while we're here, let's also allow `with_tenant` even though my slight preference would be to force developers to use the connection class. Sharp knives, etc.