### PR TITLE
Rails console sets current tenant in local envs

### DIFF
--- a/lib/active_record/tenanted/console.rb
+++ b/lib/active_record/tenanted/console.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Tenanted
+    module Console # :nodoc:
+      def start
+        ActiveRecord::Tenanted::DatabaseTasks.set_current_tenant if Rails.env.local?
+        super
+      end
+    end
+  end
+end

--- a/lib/active_record/tenanted/database_tasks.rb
+++ b/lib/active_record/tenanted/database_tasks.rb
@@ -37,7 +37,9 @@ module ActiveRecord
       def get_current_tenant
         tenant = ENV["ARTENANT"]
 
-        unless tenant.present?
+        if tenant.present?
+          warn "Setting current tenant to #{tenant.inspect}" if verbose?
+        else
           raise ArgumentError, "ARTENANT must be set in a non-local environment" unless Rails.env.local?
 
           tenant = default_tenant

--- a/lib/active_record/tenanted/railtie.rb
+++ b/lib/active_record/tenanted/railtie.rb
@@ -120,6 +120,11 @@ module ActiveRecord
       end
 
       config.after_initialize do
+        if defined?(Rails::Console)
+          require "rails/commands/console/irb_console"
+          Rails::Console::IRBConsole.prepend ActiveRecord::Tenanted::Console
+        end
+
         ActiveSupport.on_load(:action_mailbox_record) do
           if Rails.application.config.active_record_tenanted.connection_class.present? &&
              Rails.application.config.active_record_tenanted.tenanted_rails_records


### PR DESCRIPTION
By default, it will use the default environment tenant, i.e. "#{env}-tenant", but this can be overridden by setting the ARTENANT environment variable.