### PR TITLE
Fully support `Relation#load_async`

### DIFF
--- a/lib/active_record/tenanted/railtie.rb
+++ b/lib/active_record/tenanted/railtie.rb
@@ -63,6 +63,7 @@ module ActiveRecord
       initializer "active_record_tenanted.active_record_base" do
         ActiveSupport.on_load(:active_record) do
           prepend ActiveRecord::Tenanted::Base
+          ActiveRecord::Relation.prepend ActiveRecord::Tenanted::Relation
         end
       end
 

--- a/lib/active_record/tenanted/relation.rb
+++ b/lib/active_record/tenanted/relation.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Tenanted
+    module Relation # :nodoc:
+      def initialize(...)
+        super
+        @tenant = @model.current_tenant
+      end
+
+      def instantiate_records(...)
+        super.tap do |records|
+          records.each { |record| record.instance_variable_set(:@tenant, @tenant) }
+        end
+      end
+    end
+  end
+end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -22,5 +22,7 @@ module Dummy
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.active_record.async_query_executor = :global_thread_pool
   end
 end

--- a/test/smarty/config/application.rb
+++ b/test/smarty/config/application.rb
@@ -23,5 +23,7 @@ module Smarty
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.active_record.async_query_executor = :global_thread_pool
   end
 end


### PR DESCRIPTION
Set each object's tenant to the tenant of the Relation, not the current tenant when the object is instantiated.

Note that this will overwrite the (possibly incorrect) tenant set by `#initialize_tenant_attribute`, which we still need for calling `Model.new` or `Model.create!`.