### PR TITLE
Introduced `ActiveRecord::Base#tenanted?`

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -112,6 +112,7 @@ TODO:
     - [x] mixin `Subtenant`
     - [x] should error if self is not an abstract base class or if target is not tenanted abstract base class
     - [x] `.tenanted?`
+    - [x] `#tenanted?`
   - [x] shared connection pools
   - [x] all the creation and schema migration complications (we have existing tests for this)
     - [x] read and write to the schema dump file

--- a/lib/active_record/tenanted/base.rb
+++ b/lib/active_record/tenanted/base.rb
@@ -54,6 +54,10 @@ module ActiveRecord
           false
         end
       end
+
+      def tenanted?
+        false
+      end
     end
   end
 end

--- a/lib/active_record/tenanted/subtenant.rb
+++ b/lib/active_record/tenanted/subtenant.rb
@@ -31,6 +31,10 @@ module ActiveRecord
       prepended do
         prepend TenantCommon
       end
+
+      def tenanted?
+        true
+      end
     end
   end
 end

--- a/lib/active_record/tenanted/tenant.rb
+++ b/lib/active_record/tenanted/tenant.rb
@@ -196,6 +196,10 @@ module ActiveRecord
 
         prepend TenantCommon
       end
+
+      def tenanted?
+        true
+      end
     end
   end
 end

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -62,12 +62,19 @@ describe ActiveRecord::Tenanted::Base do
         assert_not(User.connection_class)
       end
 
-      test "it implements #tenanted?" do
-        assert_predicate(TenantedApplicationRecord, :tenanted?)
-        assert_predicate(User, :tenanted?)
-
+      test "it implements .tenanted?" do
         assert_not(SharedApplicationRecord.tenanted?)
         assert_not(Announcement.tenanted?)
+
+        assert_predicate(TenantedApplicationRecord, :tenanted?)
+        assert_predicate(User, :tenanted?)
+      end
+
+      test "it implements #tenanted?" do
+        assert_not(Announcement.new.tenanted?)
+        TenantedApplicationRecord.create_tenant("foo") do
+          assert_predicate(User.new, :tenanted?)
+        end
       end
 
       test "sets the default shard to UNTENANTED_SENTINEL" do


### PR DESCRIPTION
to check if an instance is tenanted without having to go to the class