### PR TITLE
Tenanted databases are no longer implicitly migrated

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -77,14 +77,10 @@ Documentation outline:
     - app.config.hosts
     - example TenantSelector
 
-- operations
-  - how to run database tasks
-    - db:migrate:tenant ARTENANT, default value of ARTENANT
-    - db:migrate:tenant:all
-  - and what assumptions have changed
-    - tenants will be migrated by `db:migrate` in dev/test but not production
-    - tenants will be migrated by `db:prepare` in dev/test but not production
-    - other database tasks do not work yet (db:create, db:seed, db:drop)
+- migrations
+  - create_tenant migrates the new database
+  - but otherwise, creation of the connection pool for a tenant that has pending migrations will raise a PendingMigrationError
+  - `db:migrate` will migrate all tenants
 
 TODO:
 


### PR DESCRIPTION
Previously, when a connection pool was created, we automatically migrated the database if necessary. We no longer do this, and instead raise a PendingMigrationError if there are pending migrations.

Tenant.create_tenant is one exception to this behavior: that method will ensure the new database has an up-to-date schema via schema dump loading and migration.

Tenant.destroy_tenant is another exception: because we don't care about the state of the database, that method skips the schema version check.

ref: https://37s.fizzy.37signals.com/collections/693169862/cards/999008694