### PR TITLE
Tear down and recreate test databases

### DIFF
--- a/lib/active_record/tenanted/testing.rb
+++ b/lib/active_record/tenanted/testing.rb
@@ -9,11 +9,13 @@ module ActiveRecord
         prepended do
           if klass = ActiveRecord::Tenanted.connection_class
             klass.current_tenant = "#{Rails.env}-tenant"
-            klass.create_tenant(klass.current_tenant, if_not_exists: true)
+            klass.destroy_tenant(klass.current_tenant)
+            klass.create_tenant(klass.current_tenant)
 
             parallelize_setup do |worker|
               klass.current_tenant = "#{Rails.env}-tenant-#{worker}"
-              klass.create_tenant(klass.current_tenant, if_not_exists: true)
+              klass.destroy_tenant(klass.current_tenant)
+              klass.create_tenant(klass.current_tenant)
             end
 
             # clean up any non-default tenants left over from the last test run


### PR DESCRIPTION
because now that migrations are not performed automatically, any migrations that get merged into your working branch will not be applied to the existing test databases and will raise a PendingMigrationError exception.