### PR TITLE
ActionText relies on the alias for generating signed id

### DIFF
--- a/lib/active_record/tenanted/tenant.rb
+++ b/lib/active_record/tenanted/tenant.rb
@@ -29,6 +29,8 @@ module ActiveRecord
         super(options.merge(tenant: tenant))
       end
 
+      alias to_sgid to_signed_global_id
+
       private def initialize_tenant_attribute
         @tenant = self.class.current_tenant
       end


### PR DESCRIPTION
If the alias is processed before the patch, it will keep the original implementation and the tenant will be missing. I could reproduce by simply uploading files to action text.