### PR TITLE
dep: bundle update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails.git
-  revision: c1d7d56e831acf0aff5f3e27a6b384f543f358d0
+  revision: 0ac3fba6ee5f7d1680024a4925eee6069095487b
   branch: main
   specs:
     actioncable (8.1.0.alpha)
@@ -115,9 +115,9 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
-    base64 (0.2.0)
-    benchmark (0.4.0)
-    bigdecimal (3.1.9)
+    base64 (0.3.0)
+    benchmark (0.4.1)
+    bigdecimal (3.2.1)
     builder (3.3.0)
     capybara (3.40.0)
       addressable
@@ -159,7 +159,7 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    json (2.12.1)
+    json (2.12.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -234,7 +234,7 @@ GEM
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rainbow (3.1.1)
-    rake (13.2.1)
+    rake (13.3.0)
     rdoc (6.14.0)
       erb
       psych (>= 4.0.0)
@@ -242,7 +242,7 @@ GEM
     reline (0.6.1)
       io-console (~> 0.5)
     rexml (3.4.1)
-    rubocop (1.75.7)
+    rubocop (1.75.8)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -279,7 +279,7 @@ GEM
     ruby-progressbar (1.13.0)
     rubyzip (2.4.1)
     securerandom (0.4.1)
-    selenium-webdriver (4.32.0)
+    selenium-webdriver (4.33.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
@@ -311,10 +311,10 @@ GEM
     tailwindcss-rails (4.2.3)
       railties (>= 7.0.0)
       tailwindcss-ruby (~> 4.0)
-    tailwindcss-ruby (4.1.7-arm64-darwin)
-    tailwindcss-ruby (4.1.7-x86_64-darwin)
-    tailwindcss-ruby (4.1.7-x86_64-linux-gnu)
-    tailwindcss-ruby (4.1.7-x86_64-linux-musl)
+    tailwindcss-ruby (4.1.8-arm64-darwin)
+    tailwindcss-ruby (4.1.8-x86_64-darwin)
+    tailwindcss-ruby (4.1.8-x86_64-linux-gnu)
+    tailwindcss-ruby (4.1.8-x86_64-linux-musl)
     thor (1.3.2)
     timeout (0.4.3)
     turbo-rails (2.0.13)
@@ -328,7 +328,7 @@ GEM
     uri (1.0.3)
     useragent (0.16.11)
     websocket (1.2.11)
-    websocket-driver (0.7.7)
+    websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
rails: c1d7d56e → 0ac3fba6

- [x] base64: 0.2.0 -> 0.3.0
  - used by active_record-tenanted, importmap-rails, jbuilder, propshaft, rubocop-rails, selenium-webdriver, solid_cable, solid_cache, solid_queue, stimulus-rails, tailwindcss-rails, turbo-rails
- [x] benchmark: 0.4.0 -> 0.4.1
  - used by active_record-tenanted, importmap-rails, jbuilder, propshaft, rubocop-rails, solid_cable, solid_cache, solid_queue, stimulus-rails, tailwindcss-rails, turbo-rails
- [x] bigdecimal: 3.1.9 -> 3.2.1
  - used by active_record-tenanted, importmap-rails, jbuilder, propshaft, rubocop-rails, solid_cable, solid_cache, solid_queue, stimulus-rails, tailwindcss-rails, turbo-rails
- [x] rake: 13.2.1 -> 13.3.0
  - used by active_record-tenanted, importmap-rails, propshaft, solid_cable, solid_cache, solid_queue, stimulus-rails, tailwindcss-rails, turbo-rails
- [x] json: 2.12.1 -> 2.12.2
  - used by rubocop-minitest, rubocop-packaging, rubocop-performance, rubocop-rails, rubocop-rake
- [x] rubocop: 1.75.7 -> 1.75.8
  - used by rubocop-minitest, rubocop-packaging, rubocop-performance, rubocop-rails, rubocop-rake
- [x] websocket-driver: 0.7.7 -> 0.8.0
  - used by solid_cable
- [x] tailwindcss-ruby: 4.1.7 -> 4.1.8
  - used by tailwindcss-rails