### PR TITLE
Allow an integer for tenant name

### DIFF
--- a/lib/active_record/tenanted/database_configurations.rb
+++ b/lib/active_record/tenanted/database_configurations.rb
@@ -11,6 +11,7 @@ module ActiveRecord
         end
 
         def database_for(tenant_name)
+          tenant_name = tenant_name.to_s
           if tenant_name.match?(%r{[/'"`]})
             raise BadTenantNameError, "Tenant name contains an invalid character: #{tenant_name.inspect}"
           end


### PR DESCRIPTION
so that applications can tenant by an external account number, for example.