### PR TITLE
Simplify the Action Cable integration

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -351,8 +351,8 @@ Documentation outline:
 
 - explain why we need to be careful
 - how to tenant a channel
- - `tenanted_connection`
-- how the global id contains tenant also
+  - make sure to call `super` if you override `#connect`
+- how the global id also contains the tenant
 - do we need to document each adapter?
   - async
   - test
@@ -362,12 +362,13 @@ Documentation outline:
 TODO:
 
 - [x] extend the base connection to support tenanting with a `tenanted_connection` method
+- [x] reconsider the current API using `tenanted_connection` if we can figure out how to reliably wrap `#connect`
+  - did this! prefer to force the app to call super() from `#connect`, it's simpler
 - [ ] test disconnection
   - `ActionCable.server.remote_connections.where(current_tenant: "foo", current_user: User.find(1)).disconnect`
   - can we make this easier to use by implying the current tenant?
 - [ ] add tenant to the action_cable logger tags
 - [ ] add integration testing around executing a command (similar to Job testing)
-- [ ] reconsider the current API using `tenanted_connection` if we can figure out how to reliably wrap `#connect`
 
 
 ### Turbo Rails

--- a/test/integration/app/channels/application_cable/connection.rb
+++ b/test/integration/app/channels/application_cable/connection.rb
@@ -1,5 +1,4 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
-    tenanted_connection
   end
 end

--- a/test/integration/test/action_cable_test.rb
+++ b/test/integration/test/action_cable_test.rb
@@ -54,4 +54,17 @@ class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
   ensure
     Rails.application.config.active_record_tenanted.tenant_resolver = @old_tenant_resolver
   end
+
+  test "untenanted request" do
+    @old_tenant_resolver = Rails.application.config.active_record_tenanted.tenant_resolver
+    Rails.application.config.active_record_tenanted.tenant_resolver = ->(request) { nil }
+
+    ApplicationRecord.without_tenant do
+      connect
+    end
+
+    assert_nil(connection.current_tenant)
+  ensure
+    Rails.application.config.active_record_tenanted.tenant_resolver = @old_tenant_resolver
+  end
 end


### PR DESCRIPTION
and set the pattern that initialization of tenant metadata is done in the `#connect` method, which will make setting script_name easier in upcoming commits.