### PR TITLE
Enhance inspect method to include tenant name in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # `activerecord-tenanted` Changelog
 
-## 0.2.0
+## next / unreleased
+
+### Added
+
+- `#inspect` on instances of tenanted models includes the tenant. #155, #161 @miguelmarcondesf @flavorjones
+
+
+## 0.2.0 / 2025-09-04
 
 First release.
 
 
 ## 0.1.0
 
-Empty gem file to squat on the name.
+Empty gem file to claim the name.

--- a/lib/active_record/tenanted/tenant.rb
+++ b/lib/active_record/tenanted/tenant.rb
@@ -17,7 +17,7 @@ module ActiveRecord
       end
 
       def inspect
-        tenant ? super.sub(/>$/, " tenant=#{tenant}>") : super
+        tenant ? super.sub(/>$/, ", tenant=#{tenant.inspect}>") : super
       end
 
       def to_global_id(options = {})

--- a/test/unit/tenant_test.rb
+++ b/test/unit/tenant_test.rb
@@ -1109,7 +1109,7 @@ describe ActiveRecord::Tenanted::Tenant do
       describe "created in untenanted context" do
         setup { with_schema_cache_dump_file }
 
-        test "includes the tenant name" do
+        test "does not include the tenant name" do
           user = User.new(email: "user1@example.org")
 
           assert_equal("users/new", user.cache_key)
@@ -1150,11 +1150,7 @@ describe ActiveRecord::Tenanted::Tenant do
             User.create!(email: "user1@example.org")
           end
 
-          assert_match(/tenant=foo/, user.inspect)
-
-          TenantedApplicationRecord.with_tenant("foo") do
-            assert_match(/tenant=foo/, User.find(user.id).inspect)
-          end
+          assert_match(/, tenant="foo">$/, user.inspect)
         end
       end
     end


### PR DESCRIPTION
Closes [#inspect value should include tenant on tenanted models](https://github.com/basecamp/activerecord-tenanted/issues/155)