### PR TITLE
`TenantSelector` middleware no longer directly renders a 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `#inspect` on instances of tenanted models includes the tenant. #155, #161 @miguelmarcondesf @flavorjones
+- `TenantSelector` middleware no longer directly renders a 404. Instead, it configures ActionDispatch::ShowExceptions middlware and raises an appropriate exception. #167 @flavorjones
 
 
 ## 0.2.0 / 2025-09-04

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,6 @@ PATH
   specs:
     activerecord-tenanted (0.2.0)
       activerecord (>= 8.1.alpha)
-      rack-contrib (>= 2.5.0)
       railties (>= 8.1.alpha)
       zeitwerk
 
@@ -217,8 +216,6 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.1)
-    rack-contrib (2.5.0)
-      rack (< 4)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)

--- a/activerecord-tenanted.gemspec
+++ b/activerecord-tenanted.gemspec
@@ -29,7 +29,5 @@ Gem::Specification.new do |spec|
   rails_requirement = ">= 8.1.alpha"
   spec.add_dependency "activerecord", rails_requirement
   spec.add_dependency "railties", rails_requirement
-
-  spec.add_dependency "rack-contrib", ">= 2.5.0"
   spec.add_dependency "zeitwerk"
 end

--- a/lib/active_record/tenanted/railtie.rb
+++ b/lib/active_record/tenanted/railtie.rb
@@ -137,6 +137,10 @@ module ActiveRecord
         end
       end
 
+      initializer "active_record_tenanted.action_dispatch", before: "action_dispatch.configure" do
+        config.action_dispatch.rescue_responses["ActiveRecord::Tenanted::TenantDoesNotExistError"] = :not_found
+      end
+
       config.after_initialize do
         if defined?(Rails::Console)
           require "rails/commands/console/irb_console"

--- a/lib/active_record/tenanted/tenant_selector.rb
+++ b/lib/active_record/tenanted/tenant_selector.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rack/contrib"
-
 module ActiveRecord
   module Tenanted
     #
@@ -34,8 +32,7 @@ module ActiveRecord
         elsif tenanted_class.tenant_exist?(tenant_name)
           tenanted_class.with_tenant(tenant_name) { @app.call(env) }
         else
-          Rails.logger.info("ActiveRecord::Tenanted::TenantSelector: Tenant not found: #{tenant_name.inspect}")
-          Rack::NotFound.new(Rails.root.join("public/404.html")).call(env)
+          raise ActiveRecord::Tenanted::TenantDoesNotExistError, "Tenant not found: #{tenant_name.inspect}"
         end
       end
 

--- a/test/integration/test/testcase_test.rb
+++ b/test/integration/test/testcase_test.rb
@@ -41,6 +41,14 @@ class TestActionDispatchIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "middleware: to a nonexistent tenant domain" do
+    integration_session.host = "nonexistent-tenant.example.com"
+
+    get notes_url
+
+    assert_response :not_found
+  end
+
   test "middleware: creating a new tenant and requesting that domain" do
     note = ApplicationRecord.create_tenant("non-default-tenant") do
       Note.create!(title: "asdf", body: "Lorem ipsum.")

--- a/test/unit/tenant_selector_test.rb
+++ b/test/unit/tenant_selector_test.rb
@@ -41,13 +41,12 @@ describe ActiveRecord::Tenanted::TenantSelector do
     describe "when nonexistent tenant is resolved" do
       let(:resolver) { ->(request) { "does-not-exist" } }
 
-      test "returns 404" do
+      test "raises TenantDoesNotExistError" do
+        # Note that in production, this exception is handled by the ShowExceptions middleware, which
+        # will raise a 404. That behavior is covered by integration tests.
         selector = ActiveRecord::Tenanted::TenantSelector.new(fake_app)
 
-        response = selector.call(fake_env)
-
-        assert_nil(fake_app.env, "Rack app should not have been invoked")
-        assert_equal(404, response.first)
+        assert_raises(ActiveRecord::Tenanted::TenantDoesNotExistError) { selector.call(fake_env) }
       end
     end
 


### PR DESCRIPTION
Instead it configures the `ShowExceptions` middleware and raises an appropriate exception.

Closes #167 