### PR TITLE
Database configuration cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # `activerecord-tenanted` Changelog
 
+## next / unreleased
+
+- Rename `ActiveRecord::Tenanted::DatabaseConfigurations::RootConfig` to `BaseConfig`.
+
+
 ## 0.3.0 / 2025-09-09
 
 ### Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## next / unreleased
 
 - Rename `ActiveRecord::Tenanted::DatabaseConfigurations::RootConfig` to `BaseConfig`.
+- Call `ActiveRecord::DatabaseConfigurations.register_db_config_handler` from the railtie.
 
 
 ## 0.3.0 / 2025-09-09

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -390,10 +390,10 @@ Documentation outline:
 
 TODO:
 
-- implement `AR::Tenanted::DatabaseConfigurations::RootConfig`
-  - [x] create the specialized RootConfig for `tenanted: true` databases
-  - [x] RootConfig disables database tasks initially
-  - [x] RootConfig raises if a connection is attempted
+- implement `AR::Tenanted::DatabaseConfigurations::BaseConfig`
+  - [x] create the specialized BaseConfig for `tenanted: true` databases
+  - [x] BaseConfig disables database tasks initially
+  - [x] BaseConfig raises if a connection is attempted
   - [x] `#database_path_for(tenant_name)`
   - [x] `#tenants` returns all the tenants on disk (for iteration)
   - [x] raise an exception if tenant name contains a path separator

--- a/lib/active_record/tenanted/database_configurations.rb
+++ b/lib/active_record/tenanted/database_configurations.rb
@@ -15,10 +15,3 @@ module ActiveRecord
     end
   end
 end
-
-# Do this here instead of the railtie so we register the handlers before Rails's rake tasks get
-# loaded. If the handler is not present, then the BaseConfigs will not return false from
-# `#database_tasks?` and the database tasks will get created anyway.
-#
-# TODO: This can be moved back into the railtie if https://github.com/rails/rails/pull/54959 is merged.
-ActiveRecord::Tenanted::DatabaseConfigurations.register_db_config_handler

--- a/lib/active_record/tenanted/database_configurations.rb
+++ b/lib/active_record/tenanted/database_configurations.rb
@@ -5,153 +5,11 @@ require "active_record/database_configurations"
 module ActiveRecord
   module Tenanted
     module DatabaseConfigurations
-      class RootConfig < ActiveRecord::DatabaseConfigurations::HashConfig
-        attr_accessor :test_worker_id
-
-        def initialize(...)
-          super
-          @test_worker_id = nil
-        end
-
-        def database_tasks?
-          false
-        end
-
-        def database_for(tenant_name)
-          tenant_name = tenant_name.to_s
-
-          validate_tenant_name(tenant_name)
-
-          path = sprintf(database, tenant: tenant_name)
-
-          if test_worker_id
-            test_worker_path(path)
-          else
-            path
-          end
-        end
-
-        def database_path_for(tenant_name)
-          coerce_path(database_for(tenant_name))
-        end
-
-        def tenants
-          glob = database_path_for("*")
-          scanner = Regexp.new(database_path_for("(.+)"))
-
-          Dir.glob(glob).map do |path|
-            result = path.scan(scanner).flatten.first
-            if result.nil?
-              warn "WARN: ActiveRecord::Tenanted: Cannot parse tenant name from filename #{path.inspect}. " \
-                   "This is a bug, please report it to https://github.com/basecamp/activerecord-tenanted/issues"
-            end
-            result
-          end
-        end
-
-        def new_tenant_config(tenant_name)
-          config_name = "#{name}_#{tenant_name}"
-          config_hash = configuration_hash.dup.tap do |hash|
-            hash[:tenant] = tenant_name
-            hash[:database] = database_for(tenant_name)
-            hash[:database_path] = database_path_for(tenant_name)
-            hash[:tenanted_config_name] = name
-          end
-          Tenanted::DatabaseConfigurations::TenantConfig.new(env_name, config_name, config_hash)
-        end
-
-        def new_connection
-          raise NoTenantError, "Cannot use an untenanted ActiveRecord::Base connection. " \
-                               "If you have a model that inherits directly from ActiveRecord::Base, " \
-                               "make sure to use 'subtenant_of'. In development, you may see this error " \
-                               "if constant reloading is not being done properly."
-        end
-
-        private
-          # A sqlite database path can be a file path or a URI (either relative or absolute).
-          # We can't parse it as a standard URI in all circumstances, though, see https://sqlite.org/uri.html
-          def coerce_path(path)
-            if path.start_with?("file:/")
-              URI.parse(path).path
-            elsif path.start_with?("file:")
-              URI.parse(path.sub(/\?.*$/, "")).opaque
-            else
-              path
-            end
-          end
-
-          def validate_tenant_name(tenant_name)
-            if tenant_name.match?(%r{[/'"`]})
-              raise BadTenantNameError, "Tenant name contains an invalid character: #{tenant_name.inspect}"
-            end
-          end
-
-          def test_worker_path(path)
-            test_worker_suffix = "_#{test_worker_id}"
-
-            if path.start_with?("file:") && path.include?("?")
-              path.sub(/(\?.*)$/, "#{test_worker_suffix}\\1")
-            else
-              path + test_worker_suffix
-            end
-          end
-      end
-
-      class TenantConfig < ActiveRecord::DatabaseConfigurations::HashConfig
-        def tenant
-          configuration_hash.fetch(:tenant)
-        end
-
-        def new_connection
-          ensure_database_directory_exists # adapter doesn't handle this if the database is a URI
-          super.tap { |conn| conn.tenant = tenant }
-        end
-
-        def tenanted_config_name
-          configuration_hash.fetch(:tenanted_config_name)
-        end
-
-        def primary?
-          ActiveRecord::Base.configurations.primary?(tenanted_config_name)
-        end
-
-        def schema_dump(format = ActiveRecord.schema_format)
-          if configuration_hash.key?(:schema_dump) || primary?
-            super
-          else
-            "#{tenanted_config_name}_#{schema_file_type(format)}"
-          end
-        end
-
-        def default_schema_cache_path(db_dir = "db")
-          if primary?
-            super
-          else
-            File.join(db_dir, "#{tenanted_config_name}_schema_cache.yml")
-          end
-        end
-
-        def database_path
-          configuration_hash[:database_path]
-        end
-
-        private
-          def ensure_database_directory_exists
-            return unless database_path
-
-            database_dir = File.dirname(database_path)
-            unless File.directory?(database_dir)
-              FileUtils.mkdir_p(database_dir)
-            end
-          end
-      end
-
-      # Invoked by the railtie
       def self.register_db_config_handler # :nodoc:
         ActiveRecord::DatabaseConfigurations.register_db_config_handler do |env_name, name, _, config|
           next unless config.fetch(:tenanted, false)
 
-          ActiveRecord::Tenanted::DatabaseConfigurations::RootConfig.new(env_name, name, config)
+          ActiveRecord::Tenanted::DatabaseConfigurations::BaseConfig.new(env_name, name, config)
         end
       end
     end
@@ -159,7 +17,7 @@ module ActiveRecord
 end
 
 # Do this here instead of the railtie so we register the handlers before Rails's rake tasks get
-# loaded. If the handler is not present, then the RootConfigs will not return false from
+# loaded. If the handler is not present, then the BaseConfigs will not return false from
 # `#database_tasks?` and the database tasks will get created anyway.
 #
 # TODO: This can be moved back into the railtie if https://github.com/rails/rails/pull/54959 is merged.

--- a/lib/active_record/tenanted/database_configurations/base_config.rb
+++ b/lib/active_record/tenanted/database_configurations/base_config.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Tenanted
+    module DatabaseConfigurations
+      class BaseConfig < ActiveRecord::DatabaseConfigurations::HashConfig
+        attr_accessor :test_worker_id
+
+        def initialize(...)
+          super
+          @test_worker_id = nil
+        end
+
+        def database_tasks?
+          false
+        end
+
+        def database_for(tenant_name)
+          tenant_name = tenant_name.to_s
+
+          validate_tenant_name(tenant_name)
+
+          path = sprintf(database, tenant: tenant_name)
+
+          if test_worker_id
+            test_worker_path(path)
+          else
+            path
+          end
+        end
+
+        def database_path_for(tenant_name)
+          coerce_path(database_for(tenant_name))
+        end
+
+        def tenants
+          glob = database_path_for("*")
+          scanner = Regexp.new(database_path_for("(.+)"))
+
+          Dir.glob(glob).map do |path|
+            result = path.scan(scanner).flatten.first
+            if result.nil?
+              warn "WARN: ActiveRecord::Tenanted: Cannot parse tenant name from filename #{path.inspect}. " \
+                   "This is a bug, please report it to https://github.com/basecamp/activerecord-tenanted/issues"
+            end
+            result
+          end
+        end
+
+        def new_tenant_config(tenant_name)
+          config_name = "#{name}_#{tenant_name}"
+          config_hash = configuration_hash.dup.tap do |hash|
+            hash[:tenant] = tenant_name
+            hash[:database] = database_for(tenant_name)
+            hash[:database_path] = database_path_for(tenant_name)
+            hash[:tenanted_config_name] = name
+          end
+          Tenanted::DatabaseConfigurations::TenantConfig.new(env_name, config_name, config_hash)
+        end
+
+        def new_connection
+          raise NoTenantError, "Cannot use an untenanted ActiveRecord::Base connection. " \
+                               "If you have a model that inherits directly from ActiveRecord::Base, " \
+                               "make sure to use 'subtenant_of'. In development, you may see this error " \
+                               "if constant reloading is not being done properly."
+        end
+
+        private
+          # A sqlite database path can be a file path or a URI (either relative or absolute).
+          # We can't parse it as a standard URI in all circumstances, though, see https://sqlite.org/uri.html
+          def coerce_path(path)
+            if path.start_with?("file:/")
+              URI.parse(path).path
+            elsif path.start_with?("file:")
+              URI.parse(path.sub(/\?.*$/, "")).opaque
+            else
+              path
+            end
+          end
+
+          def validate_tenant_name(tenant_name)
+            if tenant_name.match?(%r{[/'"`]})
+              raise BadTenantNameError, "Tenant name contains an invalid character: #{tenant_name.inspect}"
+            end
+          end
+
+          def test_worker_path(path)
+            test_worker_suffix = "_#{test_worker_id}"
+
+            if path.start_with?("file:") && path.include?("?")
+              path.sub(/(\?.*)$/, "#{test_worker_suffix}\\1")
+            else
+              path + test_worker_suffix
+            end
+          end
+      end
+    end
+  end
+end

--- a/lib/active_record/tenanted/railtie.rb
+++ b/lib/active_record/tenanted/railtie.rb
@@ -57,6 +57,12 @@ module ActiveRecord
       # Defaults to "development-tenant" in development and "test-tenant" in test environments.
       config.active_record_tenanted.default_tenant = Rails.env.local? ? "#{Rails.env}-tenant" : nil
 
+      config.before_configuration do
+        ActiveSupport.on_load(:active_record_database_configurations) do
+          ActiveRecord::Tenanted::DatabaseConfigurations.register_db_config_handler
+        end
+      end
+
       config.before_initialize do
         Rails.application.configure do
           if config.active_record_tenanted.connection_class.present?

--- a/lib/active_record/tenanted/tenant.rb
+++ b/lib/active_record/tenanted/tenant.rb
@@ -165,7 +165,7 @@ module ActiveRecord
         end
 
         def tenants
-          # DatabaseConfigurations::RootConfig#tenants returns all tenants whose database files
+          # DatabaseConfigurations::BaseConfig#tenants returns all tenants whose database files
           # exist, but some of those may be getting initially migrated, so we perform an additional
           # filter on readiness with `tenant_exist?`.
           tenanted_root_config.tenants.select { |t| tenant_exist?(t) }

--- a/lib/active_record/tenanted/testing.rb
+++ b/lib/active_record/tenanted/testing.rb
@@ -73,9 +73,9 @@ module ActiveRecord
         def transactional_tests_for_pool?(pool)
           config = pool.db_config
 
-          # Prevent the tenanted RootConfig from creating transactional fixtures on an unnecessary
+          # Prevent the tenanted BaseConfig from creating transactional fixtures on an unnecessary
           # database, which would result in sporadic locking errors.
-          is_root_config = config.instance_of?(Tenanted::DatabaseConfigurations::RootConfig)
+          is_root_config = config.instance_of?(Tenanted::DatabaseConfigurations::BaseConfig)
 
           # Any tenanted database that isn't the default test fixture database should not be wrapped
           # in a transaction, for a couple of reasons:

--- a/test/unit/database_configurations_test.rb
+++ b/test/unit/database_configurations_test.rb
@@ -8,26 +8,26 @@ describe ActiveRecord::Tenanted::DatabaseConfigurations do
 
   describe Rails do
     with_scenario(:primary_named_db, :primary_record) do
-      test "instantiates a RootConfig for the tenanted database" do
+      test "instantiates a BaseConfig for the tenanted database" do
         assert_equal(
           {
-            "tenanted" => ActiveRecord::Tenanted::DatabaseConfigurations::RootConfig,
+            "tenanted" => ActiveRecord::Tenanted::DatabaseConfigurations::BaseConfig,
             "shared" => ActiveRecord::DatabaseConfigurations::HashConfig,
           },
           all_configs.each_with_object({}) { |c, h| h[c.name] = c.class }
         )
       end
 
-      test "the RootConfig has tasks turned off by default" do
+      test "the BaseConfig has tasks turned off by default" do
         assert_not tenanted_config.database_tasks?
       end
     end
   end
 
-  describe "RootConfig" do
+  describe "BaseConfig" do
     describe ".database_path_for and .tenants" do
       let(:config_hash) { { adapter: "sqlite3", database: database } }
-      let(:config) { ActiveRecord::Tenanted::DatabaseConfigurations::RootConfig.new("test", "foo", config_hash) }
+      let(:config) { ActiveRecord::Tenanted::DatabaseConfigurations::BaseConfig.new("test", "foo", config_hash) }
 
       describe "file path" do
         let(:dir) { Dir.mktmpdir("database-path-for-tenants") }


### PR DESCRIPTION
- Rename `DatabaseConfigurations::RootConfig` to `BaseConfig`
- Call `register_db_config_handler` from the railtie

These are non-functional changes, and the rename should not affect any application properly using the API.
