### PR TITLE
Make sure debug is available in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,14 +4,11 @@ source "https://rubygems.org"
 
 gemspec
 
-group :development do
+group :development, :test do
   gem "rails", github: "rails/rails", branch: "main"
   gem "sqlite3", "2.7.4"
-  gem "minitest-parallel_fork", "2.1.0"
-end
-
-group :test, :development do
   gem "debug", "1.11.0"
+  gem "minitest-parallel_fork", "2.1.0", require: false
 end
 
 group :rubocop do

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,11 @@ gemspec
 group :development do
   gem "rails", github: "rails/rails", branch: "main"
   gem "sqlite3", "2.7.3"
-  gem "debug", "1.11.0"
   gem "minitest-parallel_fork", "2.1.0"
+end
+
+group :test, :development do
+  gem "debug", "1.11.0"
 end
 
 group :rubocop do


### PR DESCRIPTION
This is just a small quality of life thing that makes sure the debug gem is available when running tests.

I tested this by putting binding.b in a test file and running bin/test-unit. Before this change my debugger wasn't caught but now it is! 

