### PR TITLE
#201 | Enhanced tenanted and untenanted associations

### DIFF
--- a/lib/active_record/tenanted/cross_tenant_associations.rb
+++ b/lib/active_record/tenanted/cross_tenant_associations.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Tenanted
+    module CrossTenantAssociations
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def has_one(name, scope = nil, **options)
+          enhanced_scope = enhance_cross_tenant_association(name, scope, options, :has_one)
+          super(name, enhanced_scope, **options)
+        end
+
+        private
+          def enhance_cross_tenant_association(name, scope, options, association_type)
+            target_class = options[:class_name]&.constantize || name.to_s.classify.constantize
+
+            unless target_class.tenanted?
+              tenant_column = options[:tenant_column] || :tenant_id
+
+              return ->(record) {
+                base_scope = scope ? target_class.instance_exec(&scope) : target_class.all
+                base_scope.where(tenant_column => record.tenant)
+              }
+            end
+
+            scope
+          end
+      end
+    end
+  end
+end

--- a/lib/active_record/tenanted/subtenant.rb
+++ b/lib/active_record/tenanted/subtenant.rb
@@ -6,6 +6,11 @@ module ActiveRecord
       extend ActiveSupport::Concern
 
       class_methods do
+        def has_one(name, scope = nil, **options)
+          enhanced_scope = enhance_cross_tenant_association(name, scope, options, :has_one)
+          super(name, enhanced_scope, **options)
+        end
+
         def tenanted?
           true
         end
@@ -21,6 +26,23 @@ module ActiveRecord
         end
 
         delegate :current_tenant, :connection_pool, to: :tenanted_subtenant_of
+
+        private
+
+        def enhance_cross_tenant_association(name, scope, options, association_type)
+          target_class = options[:class_name]&.constantize || name.to_s.classify.constantize
+
+          unless target_class.tenanted?
+            tenant_column = options[:tenant_column] || :tenant_id
+
+            return ->(record) {
+              base_scope = scope ? target_class.instance_exec(&scope) : target_class.all
+              base_scope.where(tenant_column => record.tenant)
+            }
+          end
+
+          scope
+        end
       end
 
       prepended do

--- a/lib/active_record/tenanted/subtenant.rb
+++ b/lib/active_record/tenanted/subtenant.rb
@@ -6,10 +6,7 @@ module ActiveRecord
       extend ActiveSupport::Concern
 
       class_methods do
-        def has_one(name, scope = nil, **options)
-          enhanced_scope = enhance_cross_tenant_association(name, scope, options, :has_one)
-          super(name, enhanced_scope, **options)
-        end
+        include CrossTenantAssociations::ClassMethods
 
         def tenanted?
           true
@@ -26,23 +23,6 @@ module ActiveRecord
         end
 
         delegate :current_tenant, :connection_pool, to: :tenanted_subtenant_of
-
-        private
-
-        def enhance_cross_tenant_association(name, scope, options, association_type)
-          target_class = options[:class_name]&.constantize || name.to_s.classify.constantize
-
-          unless target_class.tenanted?
-            tenant_column = options[:tenant_column] || :tenant_id
-
-            return ->(record) {
-              base_scope = scope ? target_class.instance_exec(&scope) : target_class.all
-              base_scope.where(tenant_column => record.tenant)
-            }
-          end
-
-          scope
-        end
       end
 
       prepended do

--- a/lib/active_record/tenanted/tenant.rb
+++ b/lib/active_record/tenanted/tenant.rb
@@ -228,6 +228,15 @@ module ActiveRecord
           pool
         end
 
+        def has_one(name, scope = nil, **options)
+          p "HELLO"
+          p name
+          p scope
+          p options
+          enhanced_scope = enhance_cross_tenant_association(name, scope, options, :has_one)
+          super(name, enhanced_scope, **options)
+        end
+
         private
           def retrieve_connection_pool(strict:)
             role = current_role
@@ -256,6 +265,21 @@ module ActiveRecord
             else
               yield
             end
+          end
+
+          def enhance_cross_tenant_association(name, scope, options, association_type)
+            target_class = options[:class_name]&.constantize || name.to_s.classify.constantize
+
+            unless target_class.tenanted?
+              tenant_column = options[:tenant_column] || :tenant_id
+
+              return ->(record) {
+                base_scope = scope ? target_class.instance_exec(&scope) : target_class.all
+                base_scope.where(tenant_column => record.tenant)
+              }
+            end
+
+            scope
           end
       end
 

--- a/lib/active_record/tenanted/tenant.rb
+++ b/lib/active_record/tenanted/tenant.rb
@@ -85,6 +85,8 @@ module ActiveRecord
       CONNECTION_POOL_CREATION_LOCK = Thread::Mutex.new # :nodoc:
 
       class_methods do
+        include CrossTenantAssociations::ClassMethods
+
         def tenanted?
           true
         end
@@ -228,14 +230,6 @@ module ActiveRecord
           pool
         end
 
-        def has_one(name, scope = nil, **options)
-          p "HELLO"
-          p name
-          p scope
-          p options
-          enhanced_scope = enhance_cross_tenant_association(name, scope, options, :has_one)
-          super(name, enhanced_scope, **options)
-        end
 
         private
           def retrieve_connection_pool(strict:)
@@ -265,21 +259,6 @@ module ActiveRecord
             else
               yield
             end
-          end
-
-          def enhance_cross_tenant_association(name, scope, options, association_type)
-            target_class = options[:class_name]&.constantize || name.to_s.classify.constantize
-
-            unless target_class.tenanted?
-              tenant_column = options[:tenant_column] || :tenant_id
-
-              return ->(record) {
-                base_scope = scope ? target_class.instance_exec(&scope) : target_class.all
-                base_scope.where(tenant_column => record.tenant)
-              }
-            end
-
-            scope
           end
       end
 


### PR DESCRIPTION
[feature: Easy associations between tenanted and untenanted models](https://github.com/basecamp/activerecord-tenanted/issues/201)

> enhance active record associations to detect if they're between a tenanted model and an untenanted model, and in that case do the extra work to make sure the tenant is respected.

Checklist:
- [x] `has_one`
- [x] `has_many`
- [ ] `belongs_to`
- [ ] Fixtures double check 