### PR TITLE
Use the ActiveRecord::QueryLogs API to inject into query logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,32 @@ Some additional changes:
 - `ActiveRecord::Tenanted.base_configs` is a new utility method that returns all the tenanted base configs for the current environment.
 
 
+### Breaking change: SQL query logging
+
+Recent cascading changes on Rails `main` related to structured logging have made it challenging to continue to support log output like this:
+
+```
+# old log structure
+Account Count [tenant=686465299] (0.1ms)  SELECT COUNT(*) FROM "accounts"
+```
+
+This version of the gem moves to using a query log tag named `:tenant`, which is more in line with how Rails wants extensions to inject content into the query logs. To use it, set this in your application config:
+
+```ruby
+Rails.application.config.active_record.query_log_tags_enabled = true
+Rails.application.config.active_record.query_log_tags = [ :tenant ]
+```
+
+When configured, the application will emit logs like this:
+
+```
+# new log structure
+Account Count (0.3ms)  SELECT COUNT(*) FROM "accounts" /*tenant='686465299'*/
+```
+
+Read the [Rails Guide documentation on `config.active_record.query_log_tags`](https://guides.rubyonrails.org/configuring.html#config-active-record-query-log-tags) for more information on query logs in general.
+
+
 ### Added
 
 - `UntenantedConnectionPool#size` returns the database configuration's `max_connections` value, so that code (like Solid Queue) can inspect config params without a tenant context.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -402,7 +402,9 @@ Documentation outline:
   - `.current_tenant` returns the execution context for the model connection class
 - and what we do in this gem to help manage that "current tenant" state
 - logging
-  - SQL query logs
+  - SQL query logs - see rdocs in connection_adapter.rb
+    - set `config.active_record.query_log_tags = [ :tenant ]`
+    - must also have `config.active_record.query_log_tags_enabled = true`
   - TaggedLogging and config.log_tenant_tag
   - suggest how to add to structured logs if people are doing that
 - migrations

--- a/lib/active_record/tenanted/connection_adapter.rb
+++ b/lib/active_record/tenanted/connection_adapter.rb
@@ -2,16 +2,25 @@
 
 module ActiveRecord
   module Tenanted
-    module ConnectionAdapter # :nodoc:
+    #
+    #  Extends ActiveRecord::ConnectionAdapters::AbstractAdapter with a `tenant` attribute.
+    #
+    #  This is useful in conjunction with the `:tenant` query log tag, which configures logging of
+    #  the tenant in SQL query logs (when `config.active_record.query_log_tags_enabled` is set to
+    #  `true`). For example:
+    #
+    #      Rails.application.config.active_record.query_log_tags_enabled = true
+    #      Rails.application.config.active_record.query_log_tags = [ :tenant ]
+    #
+    #  will cause the application to emit logs like:
+    #
+    #      User Load (0.2ms)  SELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT 1 /*tenant='foo'*/
+    #
+    module ConnectionAdapter
       extend ActiveSupport::Concern
 
       prepended do
         attr_accessor :tenant
-      end
-
-      def log(sql, name = "SQL", binds = [], type_casted_binds = [], async: false, allow_retry: false, &block)
-        name = [ name, "[tenant=#{tenant}]" ].compact.join(" ") if tenanted?
-        super
       end
 
       def tenanted?

--- a/lib/active_record/tenanted/database_configurations/tenant_config.rb
+++ b/lib/active_record/tenanted/database_configurations/tenant_config.rb
@@ -18,11 +18,11 @@ module ActiveRecord
         end
 
         def new_connection
-          # TODO: The Rails SQLite adapter doesn't handle directory creation for file: URIs. I would
-          # like to fix that upstream, and remove this line.
+          # TODO: This line can be removed once rails/rails@f1f60dc1 is in a released version of
+          # Rails, and this gem's dependency has been bumped to require that version or later.
           config_adapter.ensure_database_directory_exists
 
-          super.tap { |conn| conn.tenant = tenant }
+          super.tap { |connection| connection.tenant = tenant }
         end
 
         def tenanted_config_name

--- a/lib/active_record/tenanted/railtie.rb
+++ b/lib/active_record/tenanted/railtie.rb
@@ -148,6 +148,10 @@ module ActiveRecord
       end
 
       config.after_initialize do
+        ActiveRecord::QueryLogs.taggings = ActiveRecord::QueryLogs.taggings.merge(
+          tenant: ->(context) { context[:connection].tenant }
+        )
+
         if defined?(Rails::Console)
           require "rails/commands/console/irb_console"
           Rails::Console::IRBConsole.prepend ActiveRecord::Tenanted::Console::IRBConsole

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,12 @@ class TestSuiteRailtie < ::Rails::Railtie
   initializer "turn off the Rails integrations when running this test suite" do
     ActiveSupport.on_load(:active_record_tenanted) do
       Rails.application.config.active_record_tenanted.connection_class = nil
+      Rails.application.config.active_record.query_log_tags = [ :tenant ]
     end
+  end
+
+  initializer "enabled query log tags for tests" do
+    Rails.application.config.active_record.query_log_tags_enabled = true
   end
 end
 

--- a/test/unit/tenant_test.rb
+++ b/test/unit/tenant_test.rb
@@ -1020,7 +1020,7 @@ describe ActiveRecord::Tenanted::Tenant do
           end
         end
 
-        assert_includes(log.string, "[tenant=foo]")
+        assert_includes(log.string, "tenant='foo'")
       end
     end
 


### PR DESCRIPTION
Recent cascading changes on Rails `main` related to structured logging have made it challenging to continue to support log output like this:

```
Account Count [tenant=686465299] (0.1ms)  SELECT COUNT(*) FROM "accounts"
```

This version of the gem moves to using a query log tag named `:tenant`, which is more in line with how Rails wants extensions to inject content into the query logs. To use it, set this in your application config:

```ruby
Rails.application.config.active_record.query_log_tags_enabled = true
Rails.application.config.active_record.query_log_tags = [ :tenant ]
```

When configured, the application will emit logs like this:

```
Account Count (0.3ms)  SELECT COUNT(*) FROM "accounts" /*tenant='686465299'*/
```

Read the [Rails Guide documentation on `config.active_record.query_log_tags`](https://guides.rubyonrails.org/configuring.html#config-active-record-query-log-tags) for more information on query logs in general.