### PR TITLE
Setting current_tenant to nil now properly clears tenant context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `activerecord-tenanted` Changelog
 
+## next / unreleased
+
+### Fixed
+
+- `.current_tenant = nil` now clears the tenant context, properly setting the shard to `UNTENANTED_SENTINEL` instead of `""` @flavorjones
+
+
 ## v0.6.0 / 2025-11-05
 
 ### Breaking change: Rake tasks

--- a/lib/active_record/tenanted/tenant.rb
+++ b/lib/active_record/tenanted/tenant.rb
@@ -95,7 +95,14 @@ module ActiveRecord
         end
 
         def current_tenant=(tenant_name)
-          tenant_name = tenant_name.to_s unless tenant_name == UNTENANTED_SENTINEL
+          case tenant_name
+          when nil
+            tenant_name = UNTENANTED_SENTINEL
+          when UNTENANTED_SENTINEL
+            # no-op
+          else
+            tenant_name = tenant_name.to_s
+          end
 
           connection_class_for_self.connecting_to(shard: tenant_name, role: ActiveRecord.writing_role)
         end

--- a/test/unit/tenant_test.rb
+++ b/test/unit/tenant_test.rb
@@ -69,6 +69,18 @@ describe ActiveRecord::Tenanted::Tenant do
         assert_nothing_raised { User.first }
       end
 
+      test ".current_tenant=nil clears tenant context" do
+        assert_nil(TenantedApplicationRecord.current_tenant)
+
+        TenantedApplicationRecord.current_tenant = "foo"
+
+        assert_equal("foo", TenantedApplicationRecord.current_tenant)
+
+        TenantedApplicationRecord.current_tenant = nil
+
+        assert_nil(TenantedApplicationRecord.current_tenant)
+      end
+
       test ".current_tenant= sets tenant context for a symbol" do
         TenantedApplicationRecord.create_tenant("foo")
 


### PR DESCRIPTION
Previously, it set tenant context to "" which is very likely not what anyone intends.