### PR TITLE
Introduce callbacks for tenant change methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Read the [Rails Guide documentation on `config.active_record.query_log_tags`](ht
 
 ### Added
 
+- Add callbacks for `:with_tenant` which are invoked when `.with_tenant` is called.
+- Add callbacks for `:set_current_tenant` which are invoked when `.current_tenant=` is called.
 - `UntenantedConnectionPool#size` returns the database configuration's `max_connections` value, so that code (like Solid Queue) can inspect config params without a tenant context.
 
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -396,7 +396,11 @@ TODO:
 
 Documentation outline:
 
-  - invalid characters in a tenant name (which is database-dependent)
+- setting the tenant
+  - `.with_tenant` and `.current_tenant=`
+    - and the callbacks for each, `:with_tenant` and `:set_current_tenant`
+  - validation
+    - invalid characters in a tenant name (which is database-dependent)
     - and how the application may want to do additional validation (e.g. ICANN subdomain restrictions)
   - `#tenant` is a readonly attribute on all tenanted model instances
   - `.current_tenant` returns the execution context for the model connection class


### PR DESCRIPTION
to allow applications to extend tenant change behavior.

I'm using this functionality in my current project to cascade a _second_ tenant change in another database, something like this:

```ruby
module ApplicationRecordWithTenantZoneExtension
  extend ActiveSupport::Concern

  class_methods do
    def with_zone(&block)
      ZonedRecord.with_tenant(tenant_zone, &block)
    end

    def set_queue_zone
      ZonedRecord.current_tenant = tenant_zone
    end

    def tenant_zone
      # ... business logic to determine the "zone" for ApplicationRecord.current_tenant
    end
  end

  included do
    set_callback :with_tenant,        :around, :with_zone
    set_callback :set_current_tenant, :after,  :set_zone
  end
end

Rails.application.config.to_prepare do
  ApplicationRecord.include ApplicationRecordWithTenantZoneExtension
end
```

so that the application only needs to call `ApplicationTenant.with_tenant` and the tenant is automatically set on the secondary database as well.
