### PR TITLE
Introduce allow_untenanted_active_storage config to enable ActiveStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## next / unreleased
 
+### Added
+
+- Add `config.active_record_tenanted.allow_untenanted_active_storage` configuration option to enable ActiveStorage without a tenant context.
+  When enabled, ActiveStorage will fallback to default (non-tenanted) behavior when there is no current tenant,
+  allowing models in the primary database to use Active Storage alongside tenanted models.
+  Defaults to `false` for backward compatibility. @keshavbiswa
+
 ### Fixed
 
 - `.current_tenant = nil` now clears the tenant context, properly setting the shard to `UNTENANTED_SENTINEL` instead of `""` @flavorjones

--- a/lib/active_record/tenanted/railtie.rb
+++ b/lib/active_record/tenanted/railtie.rb
@@ -57,6 +57,18 @@ module ActiveRecord
       # Defaults to "development-tenant" in development and "test-tenant" in test environments.
       config.active_record_tenanted.default_tenant = Rails.env.local? ? "#{Rails.env}-tenant" : nil
 
+      # Set this to true to allow Active Storage to work without a tenant context.
+      #
+      # When enabled, Active Storage will fall back to default behavior (non-tenanted storage)
+      # when there is no current tenant. This allows models in the primary database to use
+      # Active Storage alongside tenanted models.
+      #
+      # When disabled (default), Active Storage will raise NoTenantError if accessed without
+      # a tenant context, maintaining strict tenant isolation.
+      #
+      # Defaults to `false`.
+      config.active_record_tenanted.allow_untenanted_active_storage = false
+
       config.before_configuration do
         ActiveSupport.on_load(:active_record_database_configurations) do
           ActiveRecord::Tenanted::DatabaseConfigurations.register_db_config_handler

--- a/test/unit/storage_test.rb
+++ b/test/unit/storage_test.rb
@@ -4,6 +4,17 @@ require "test_helper"
 
 describe ActiveRecord::Tenanted::Storage do
   describe "DiskService" do
+    let(:allow_untenanted_active_storage) { false }
+
+    setup do
+      @old_allow_untenanted = Rails.application.config.active_record_tenanted.allow_untenanted_active_storage
+      Rails.application.config.active_record_tenanted.allow_untenanted_active_storage = allow_untenanted_active_storage
+    end
+
+    teardown do
+      Rails.application.config.active_record_tenanted.allow_untenanted_active_storage = @old_allow_untenanted
+    end
+
     describe ".root" do
       with_active_storage do
         let(:service) { ActiveStorage::Service::DiskService.new(root: root_path) }
@@ -26,6 +37,24 @@ describe ActiveRecord::Tenanted::Storage do
               end
             end
           end
+
+          describe "with allow_untenanted_active_storage enabled" do
+            let(:allow_untenanted_active_storage) { true }
+
+            test "allows access without tenant" do
+              ActiveRecord::Tenanted.stub(:connection_class, TenantedApplicationRecord) do
+                assert_equal("/path/to/%{tenant}/storage", service.root)
+              end
+            end
+
+            test "uses tenant when available" do
+              ActiveRecord::Tenanted.stub(:connection_class, TenantedApplicationRecord) do
+                TenantedApplicationRecord.create_tenant("foo") do
+                  assert_equal("/path/to/foo/storage", service.root)
+                end
+              end
+            end
+          end
         end
 
         describe "with a non-tenanted root path" do
@@ -44,6 +73,55 @@ describe ActiveRecord::Tenanted::Storage do
               TenantedApplicationRecord.create_tenant("foo") do
                 assert_equal("/path/to/storage", service.root)
               end
+            end
+          end
+        end
+
+        describe "with allow_untenanted_active_storage enabled" do
+          let(:allow_untenanted_active_storage) { true }
+          let(:root_path) { "/path/to/storage" }
+
+          test "allows access while untenanted" do
+            ActiveRecord::Tenanted.stub(:connection_class, TenantedApplicationRecord) do
+              assert_equal("/path/to/storage", service.root)
+            end
+          end
+
+          test "uses current tenant while tenanted" do
+            ActiveRecord::Tenanted.stub(:connection_class, TenantedApplicationRecord) do
+              TenantedApplicationRecord.create_tenant("foo") do
+                assert_equal("/path/to/storage", service.root)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    describe ".path_for" do
+      with_active_storage do
+        let(:service) { ActiveStorage::Service::DiskService.new(root: "/path/to/storage") }
+
+        describe "with allow_untenanted_active_storage enabled" do
+          let(:allow_untenanted_active_storage) { true }
+
+          test "handles non-tenanted keys" do
+            ActiveRecord::Tenanted.stub(:connection_class, TenantedApplicationRecord) do
+              non_tenanted_key = "abc123"
+
+              expected_path = "/path/to/storage/ab/c1/#{non_tenanted_key}"
+              assert_equal expected_path, service.path_for(non_tenanted_key)
+            end
+          end
+        end
+
+        test "handles tenanted keys" do
+          ActiveRecord::Tenanted.stub(:connection_class, TenantedApplicationRecord) do
+            TenantedApplicationRecord.create_tenant("foo") do
+              tenanted_key = "foo/abc123"
+
+              expected_path = "/path/to/storage/foo/ab/c1/abc123"
+              assert_equal expected_path, service.path_for(tenanted_key)
             end
           end
         end
@@ -82,6 +160,14 @@ describe ActiveRecord::Tenanted::Storage do
             _, key = blob.key.split("/", 2)
             expected_path = "/path/to/storage/foo/#{key[0..1]}/#{key[2..3]}/#{key}"
             assert_equal expected_path, blob.service.path_for(blob.key)
+          end
+        end
+      end
+
+      test "raises exception without tenant when flag is disabled" do
+        ActiveRecord::Tenanted.stub(:connection_class, TenantedApplicationRecord) do
+          assert_raises(ActiveRecord::Tenanted::NoTenantError) do
+            ActiveStorage::Blob.new(filename: "foo.jpg", byte_size: 100, checksum: "abc123", service_name: service_name).key
           end
         end
       end


### PR DESCRIPTION
# Problem
I have a `PrimaryRecord` (untenanted) and `ApplicationRecord`(tenanted) and I need ActiveStorage to work on both untenanted records and tenanted records. Currently it only works on tenanted. 

Here's an example .

```ruby
class PrimaryRecord < ActiveRecord::Base
  self.abstract_class = true

  connects_to database: { writing: :primary, reading: :primary }
end
```

```ruby
class ApplicationRecord < ActiveRecord::Base
  primary_abstract_class

  tenanted "secondary"
end
```

```ruby
class Organization < PrimaryRecord
  has_one_attached :logo
end
```

```ruby
class User < ApplicationRecord
  has_one_attached :photo
end
```

So for tenanted works fine. 
```bash
Defaulting current tenant to "development-tenant"
app(dev):001> User.first.photo
  SCHEMA [tenant=development-tenant] (1.6ms)  SELECT sqlite_version(*) /*application='App'*/
  SCHEMA [tenant=development-tenant] (0.0ms)  PRAGMA foreign_keys = ON /*application='App'*/
  SCHEMA [tenant=development-tenant] (0.0ms)  PRAGMA journal_size_limit = 67108864 /*application='App'*/
  SCHEMA [tenant=development-tenant] (0.0ms)  PRAGMA cache_size = 2000 /*application='App'*/
  SCHEMA [tenant=development-tenant] (0.0ms)  PRAGMA journal_mode = WAL /*application='App'*/
  SCHEMA [tenant=development-tenant] (0.0ms)  PRAGMA synchronous = NORMAL /*application='App'*/
  SCHEMA [tenant=development-tenant] (0.0ms)  PRAGMA mmap_size = 134217728 /*application='App'*/
  SCHEMA [tenant=development-tenant] (2.3ms)  SELECT name FROM pragma_table_list WHERE schema <> 'temp' AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND name = 'schema_migrations' AND type IN ('table') /*application='App'*/
  SCHEMA [tenant=development-tenant] (0.0ms)  SELECT name FROM pragma_table_list WHERE schema <> 'temp' AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND name = 'ar_internal_metadata' AND type IN ('table') /*application='App'*/
  ActiveRecord::SchemaMigration Load [tenant=development-tenant] (0.1ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC /*application='App'*/
  User Load [tenant=development-tenant] (0.1ms)  SELECT "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT 1 /*application='App'*/
(app):1:in '<main>': undefined method 'photo' for nil (NoMethodError)
app(dev):002>
```

But for untenanted raises `ActiveRecord::Tenanted::TenantDoesNotExistError`

```ruby
Loading development environment (Rails 8.2.0.alpha)
Type 'help' for help.
Defaulting current tenant to "development-tenant"
app(dev):001> ApplicationRecord.current_tenant = nil
=> nil
app(dev):002> Organization.first.logo
  Organization Load (0.1ms)  SELECT "organizations".* FROM "organizations" ORDER BY "organizations"."id" ASC LIMIT 1 /*application='App'*/
An error occurred when inspecting the object: #<ActiveRecord::Tenanted::TenantDoesNotExistError: The database for tenant "" does not exist.>
=> #<ActiveStorage::Attached::One:0x0000000127034dc8
app(dev):003>
```

# Solution

This PR introduces `config.active_record_tenanted.allow_untenanted_active_storage` which by default is `false`. But if set to `true` will allow untenanted access to primary DBs as well. 
