### PR TITLE
Skip Attributes patch for Rails 8.2+

### DIFF
--- a/lib/active_record/tenanted/patches.rb
+++ b/lib/active_record/tenanted/patches.rb
@@ -24,8 +24,9 @@ module ActiveRecord
           end
       end
 
-      # TODO: This monkey patch shouldn't be necessary after 8.1 lands and the need for a
-      # connection is removed. For details see https://github.com/rails/rails/pull/54348
+      # This patch is only applied for Rails 8.1.x. Rails 8.2+ removed the with_connection
+      # call in _default_attributes (rails/rails#54333), making this patch unnecessary.
+      # See railtie.rb for the version check.
       module Attributes
         extend ActiveSupport::Concern
 

--- a/lib/active_record/tenanted/railtie.rb
+++ b/lib/active_record/tenanted/railtie.rb
@@ -95,7 +95,11 @@ module ActiveRecord
 
       initializer "active_record_tenanted.monkey_patches" do
         ActiveSupport.on_load(:active_record) do
-          prepend ActiveRecord::Tenanted::Patches::Attributes
+          # Rails 8.2+ removed the with_connection call in _default_attributes (rails/rails#54333),
+          # so this patch is only needed for Rails 8.1.x
+          if ActiveRecord.version < Gem::Version.new("8.2.0.alpha")
+            prepend ActiveRecord::Tenanted::Patches::Attributes
+          end
           ActiveRecord::Tasks::DatabaseTasks.prepend ActiveRecord::Tenanted::Patches::DatabaseTasks
         end
       end


### PR DESCRIPTION
## Summary
- Fixes #279
- Rails 8.2+ changed `type_for_column` to take 1 argument instead of 2
- Rails 8.2+ also removed the `with_connection` call in `_default_attributes` (rails/rails#54333), making the Attributes patch unnecessary
- Adds version check to only apply the patch for Rails < 8.2.0.alpha