### PR TITLE
ci: regenerate appraisal gemfiles on dependabot bundler PRs

### DIFF
--- a/.github/workflows/dependabot-appraisal-generate.yml
+++ b/.github/workflows/dependabot-appraisal-generate.yml
@@ -1,0 +1,62 @@
+name: Regenerate appraisal gemfiles
+
+on:
+  push:
+    branches:
+      - "dependabot/bundler/**"
+    paths:
+      - Gemfile
+      - Gemfile.lock
+
+permissions: {}
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Regenerate gemfiles from Appraisals
+        run: bundle exec appraisal generate
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: gemfiles
+          path: gemfiles/
+          retention-days: 1
+
+  commit:
+    needs: generate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: gemfiles
+          path: gemfiles/
+
+      - name: Commit regenerated gemfiles
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          git add gemfiles/
+          if ! git diff --cached --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git commit -m "Regenerate appraisal gemfiles"
+            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF_NAME}"
+          fi

--- a/.github/workflows/dependabot-appraisal-generate.yml
+++ b/.github/workflows/dependabot-appraisal-generate.yml
@@ -1,5 +1,9 @@
 name: Regenerate appraisal gemfiles
 
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+
 on:
   push:
     branches:
@@ -14,7 +18,7 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # checkout the dependabot branch
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -38,7 +42,7 @@ jobs:
     needs: generate
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # push regenerated gemfiles to the dependabot branch
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
When Dependabot bumps a gem in the root Gemfile, the generated gemfiles/*.gemfile go stale because nothing regenerates them. This workflow runs `appraisal generate` on dependabot/bundler/** branches and commits the result back so the PR stays self-consistent.

Split into two jobs for supply-chain hardening: `generate` installs gems and runs appraisal with contents:read only (no push-capable token), then hands the gemfiles to `commit` via an artifact. The job holding contents:write runs no gem code, so install-time RCE from a poisoned gem bump cannot reach a write token.
