### PR TITLE
fix: path traversal in `DiskService#path_for`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,8 +104,8 @@ PATH
   remote: .
   specs:
     activerecord-tenanted (0.6.0)
-      activerecord (>= 8.1.0)
-      railties (>= 8.1.0)
+      activerecord (>= 8.1.2.1)
+      railties (>= 8.1.2.1)
       zeitwerk
 
 GEM

--- a/activerecord-tenanted.gemspec
+++ b/activerecord-tenanted.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
-  rails_requirement = ">= 8.1.0"
+  rails_requirement = ">= 8.1.2.1"
   spec.add_dependency "activerecord", rails_requirement
   spec.add_dependency "railties", rails_requirement
   spec.add_dependency "zeitwerk"

--- a/lib/active_record/tenanted/storage.rb
+++ b/lib/active_record/tenanted/storage.rb
@@ -17,12 +17,31 @@ module ActiveRecord
         end
 
         def path_for(key)
-          if ActiveRecord::Tenanted.connection_class && key.include?("/")
-            tenant, key = key.split("/", 2)
-            File.join(root, tenant, folder_for(key), key)
-          else
-            super
+          return super unless ActiveRecord::Tenanted.connection_class && key.include?("/")
+
+          if key.split("/").intersect?(%w[. ..])
+            raise ActiveStorage::InvalidKeyError, "key has path traversal segments"
           end
+
+          tenant, key = key.split("/", 2)
+
+          if tenant.blank? || key.blank?
+            raise ActiveStorage::InvalidKeyError, "key has a blank segment"
+          end
+
+          begin
+            path = File.expand_path(File.join(root, tenant, folder_for(key), key))
+          rescue ArgumentError
+            raise ActiveStorage::InvalidKeyError, "key is an invalid string"
+          end
+
+          unless path.start_with?(File.expand_path(root) + "/")
+            raise ActiveStorage::InvalidKeyError, "key is outside of disk service root"
+          end
+
+          path
+        rescue Encoding::CompatibilityError
+          raise ActiveStorage::InvalidKeyError, "key has incompatible encoding"
         end
       end
 

--- a/test/unit/storage_test.rb
+++ b/test/unit/storage_test.rb
@@ -99,5 +99,45 @@ describe ActiveRecord::Tenanted::Storage do
         end
       end
     end
+
+    describe "path traversal" do
+      with_active_storage do
+        let(:service) { ActiveStorage::Service::DiskService.new(root: "/path/to/%{tenant}/storage") }
+
+        [
+          [ "directory escape",   "../../../../etc/passwd",   "key has path traversal segments" ],
+          [ "head fake escape",   "foo/../../../etc/passwd",  "key has path traversal segments" ],
+          [ "sibling directory",  "../secret/token",          "key has path traversal segments" ],
+          [ "invalid . segment",  "foo/./bar",                "key has path traversal segments" ],
+          [ "invalid .. segment", "foo/../foo/bar",           "key has path traversal segments" ],
+          [ "folder_for escape",  "foo/....secret",           "key is outside of disk service root" ],
+          [ "embedded null byte", "foo/bar\x00.jpg",          "key is an invalid string" ],
+          [ "empty key",          "foo/",                     "key has a blank segment" ],
+          [ "empty tenant",       "/token",                   "key has a blank segment" ],
+          [ "incompat encoding",  "a/b".encode("UTF-16LE"),   "key has incompatible encoding" ],
+        ].each do |test_title, malicious_key, error_message|
+          test "path_for raises InvalidKeyError for #{test_title}" do
+            ActiveRecord::Tenanted.stub(:connection_class, TenantedApplicationRecord) do
+              TenantedApplicationRecord.create_tenant("foo") do
+                e = assert_raises(ActiveStorage::InvalidKeyError) do
+                  service.path_for(malicious_key)
+                end
+
+                assert_includes e.message, error_message
+              end
+            end
+          end
+        end
+
+        test "path_for keeps a benign tenant key inside the resolved root" do
+          ActiveRecord::Tenanted.stub(:connection_class, TenantedApplicationRecord) do
+            TenantedApplicationRecord.create_tenant("foo") do
+              path = service.path_for("foo/abc123def456")
+              assert path.start_with?(File.expand_path(service.root) + "/")
+            end
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Port the upstream Rails fixes for CVE-2026-33195 to this gem's override of `ActiveStorage::Service::DiskService#path_for`, to reject dot segments, expand the path and require it to stay within the root, and convert ArgumentError (null bytes) and
Encoding::CompatibilityError into InvalidKeyError.

Also reject a blank tenant or key segment, specific to the tenant/token key layout.

Requires Rails >= 8.1.2.1, which introduces InvalidKeyError and the hardened parent path_for. Because this is still pre-release software, I'm comfortable bumping the requirement.

As the upstream commit says: These changes are defense-in-depth measures intended to limit the blast radius of developer errors, and are not a trust boundary.

ref: GHSA-pmwx-rm49-xv39