### PR TITLE
fix: implement GlobalID locator model_class

### DIFF
--- a/lib/active_record/tenanted/global_id.rb
+++ b/lib/active_record/tenanted/global_id.rb
@@ -10,20 +10,24 @@ module ActiveRecord
       end
 
       class Locator
+        def model_class(gid)
+          gid.model_name.constantize
+        end
+
         def locate(gid, options = {})
-          ensure_tenant_context_safety(gid)
-          gid.model_class.find(gid.model_id)
+          gid_model_class = model_class(gid)
+          ensure_tenant_context_safety(gid, gid_model_class)
+          gid_model_class.find(gid.model_id)
         end
 
         private
-          def ensure_tenant_context_safety(gid)
-            model_class = gid.model_class
-            return unless model_class.tenanted?
+          def ensure_tenant_context_safety(gid, gid_model_class)
+            return unless gid_model_class.tenanted?
 
             gid_tenant = gid.tenant
             raise MissingTenantError, "Tenant not present in #{gid.to_s.inspect}" unless gid_tenant
 
-            current_tenant = model_class.current_tenant.presence
+            current_tenant = gid_model_class.current_tenant.presence
             raise NoTenantError, "Cannot connect to a tenanted database while untenanted (#{gid})" unless current_tenant
 
             if gid_tenant != current_tenant

--- a/test/unit/global_id_test.rb
+++ b/test/unit/global_id_test.rb
@@ -56,6 +56,14 @@ end
 
 describe ActiveRecord::Tenanted::GlobalId::Locator do
   for_each_scenario do
+    describe "#model_class" do
+      test "returns the GID model class" do
+        gid = GlobalID.parse("gid://dummy/User/1?tenant=foo")
+
+        assert_equal(User, ActiveRecord::Tenanted::GlobalId::Locator.new.model_class(gid))
+      end
+    end
+
     describe "given an untenanted GID" do
       test "raises MissingTenantError" do
         gid = GlobalID.parse("gid://dummy/User/1")


### PR DESCRIPTION
Version 1.4 of the globalid gem now requires a #model_class method and surfaces deprecation warnings if missing. This commit addresses that in a narrow fashion. A version inheriting from GlobalID’s BaseLocator class is in https://github.com/basecamp/activerecord-tenanted/pull/318 instead.