### PR TITLE
fix: inherit from GlobalID's BaseLocator

### DIFF
--- a/lib/active_record/tenanted/global_id.rb
+++ b/lib/active_record/tenanted/global_id.rb
@@ -9,21 +9,30 @@ module ActiveRecord
         params && params[:tenant]
       end
 
-      class Locator
+      class Locator < ::GlobalID::Locator::BaseLocator
+        def model_class(gid)
+          gid.model_name.constantize
+        end
+
         def locate(gid, options = {})
           ensure_tenant_context_safety(gid)
-          gid.model_class.find(gid.model_id)
+          super
+        end
+
+        def locate_many(gids, options = {})
+          gids.each { |gid| ensure_tenant_context_safety(gid) }
+          super
         end
 
         private
           def ensure_tenant_context_safety(gid)
-            model_class = gid.model_class
-            return unless model_class.tenanted?
+            gid_model_class = model_class(gid)
+            return unless gid_model_class.tenanted?
 
             gid_tenant = gid.tenant
             raise MissingTenantError, "Tenant not present in #{gid.to_s.inspect}" unless gid_tenant
 
-            current_tenant = model_class.current_tenant.presence
+            current_tenant = gid_model_class.current_tenant.presence
             raise NoTenantError, "Cannot connect to a tenanted database while untenanted (#{gid})" unless current_tenant
 
             if gid_tenant != current_tenant

--- a/lib/active_record/tenanted/global_id.rb
+++ b/lib/active_record/tenanted/global_id.rb
@@ -16,7 +16,7 @@ module ActiveRecord
 
         def locate(gid, options = {})
           ensure_tenant_context_safety(gid, gid.model_class)
-          super
+          super(gid)
         end
 
         def locate_many(gids, options = {})

--- a/lib/active_record/tenanted/global_id.rb
+++ b/lib/active_record/tenanted/global_id.rb
@@ -15,18 +15,17 @@ module ActiveRecord
         end
 
         def locate(gid, options = {})
-          ensure_tenant_context_safety(gid)
+          ensure_tenant_context_safety(gid, gid.model_class)
           super
         end
 
         def locate_many(gids, options = {})
-          gids.each { |gid| ensure_tenant_context_safety(gid) }
+          gids.each { |gid| ensure_tenant_context_safety(gid, gid.model_class) }
           super
         end
 
         private
-          def ensure_tenant_context_safety(gid)
-            gid_model_class = model_class(gid)
+          def ensure_tenant_context_safety(gid, gid_model_class)
             return unless gid_model_class.tenanted?
 
             gid_tenant = gid.tenant

--- a/test/unit/global_id_test.rb
+++ b/test/unit/global_id_test.rb
@@ -56,6 +56,14 @@ end
 
 describe ActiveRecord::Tenanted::GlobalId::Locator do
   for_each_scenario do
+    describe "#model_class" do
+      test "returns the GID model class" do
+        gid = GlobalID.parse("gid://dummy/User/1?tenant=foo")
+
+        assert_equal(User, ActiveRecord::Tenanted::GlobalId::Locator.new.model_class(gid))
+      end
+    end
+
     describe "given an untenanted GID" do
       test "raises MissingTenantError" do
         gid = GlobalID.parse("gid://dummy/User/1")
@@ -63,6 +71,16 @@ describe ActiveRecord::Tenanted::GlobalId::Locator do
         TenantedApplicationRecord.create_tenant("foo") do
           assert_raises(ActiveRecord::Tenanted::MissingTenantError) do
             ActiveRecord::Tenanted::GlobalId::Locator.new.locate(gid)
+          end
+        end
+      end
+
+      test "raises MissingTenantError when locating many" do
+        gid = GlobalID.parse("gid://dummy/User/1")
+
+        TenantedApplicationRecord.create_tenant("foo") do
+          assert_raises(ActiveRecord::Tenanted::MissingTenantError) do
+            ActiveRecord::Tenanted::GlobalId::Locator.new.locate_many([ gid ])
           end
         end
       end
@@ -75,6 +93,19 @@ describe ActiveRecord::Tenanted::GlobalId::Locator do
           user = ActiveRecord::Tenanted::GlobalId::Locator.new.locate(original_user.to_global_id)
 
           assert_equal(original_user, user)
+        end
+      end
+
+      test "loads many correctly" do
+        TenantedApplicationRecord.create_tenant("foo") do
+          original_users = [
+            User.create!(email: "user1@example.org"),
+            User.create!(email: "user2@example.org"),
+          ]
+          user_gids = original_users.map(&:to_global_id)
+
+          assert_equal(original_users, ActiveRecord::Tenanted::GlobalId::Locator.new.locate_many(user_gids))
+          assert_equal(original_users, GlobalID::Locator.locate_many(user_gids))
         end
       end
     end
@@ -91,6 +122,18 @@ describe ActiveRecord::Tenanted::GlobalId::Locator do
           end
         end
       end
+
+      test "raises WrongTenantError when locating many" do
+        original_user = TenantedApplicationRecord.create_tenant("foo") do
+          User.create!(email: "user1@example.org")
+        end
+
+        TenantedApplicationRecord.create_tenant("bar") do
+          assert_raises(ActiveRecord::Tenanted::WrongTenantError) do
+            ActiveRecord::Tenanted::GlobalId::Locator.new.locate_many([ original_user.to_global_id ])
+          end
+        end
+      end
     end
 
     describe "in untenanted context" do
@@ -102,6 +145,18 @@ describe ActiveRecord::Tenanted::GlobalId::Locator do
         TenantedApplicationRecord.without_tenant do
           assert_raises(ActiveRecord::Tenanted::NoTenantError) do
             ActiveRecord::Tenanted::GlobalId::Locator.new.locate(original_user.to_global_id)
+          end
+        end
+      end
+
+      test "raises NoTenantError when locating many" do
+        original_user = TenantedApplicationRecord.create_tenant("foo") do
+          User.create!(email: "user1@example.org")
+        end
+
+        TenantedApplicationRecord.without_tenant do
+          assert_raises(ActiveRecord::Tenanted::NoTenantError) do
+            ActiveRecord::Tenanted::GlobalId::Locator.new.locate_many([ original_user.to_global_id ])
           end
         end
       end


### PR DESCRIPTION
Version 1.4 of the globalid gem expects custom locators to implement `model_class(gid)` or inherit from `GlobalID::Locator::BaseLocator`. Without that API, apps using GlobalID 1.4 or later emit deprecation warnings when resolving GIDs. A narrow fix for that deprecation warning is attempted in https://github.com/basecamp/activerecord-tenanted/pull/317. 

This change makes `ActiveRecord::Tenanted::GlobalId::Locator` inherit from `GlobalID::Locator::BaseLocator` instead, which additionally adds tenant validation to `locate_many` before delegating to `super` for consumers calling it.