### PR TITLE
Add `ActiveRecord::Tenanted::GlobalId::Locator#model_class`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `activerecord-tenanted` Changelog
 
+## Unreleased
+
+### Fixed
+
+- Add `ActiveRecord::Tenanted::GlobalId::Locator#model_class` to resolve deprecation warning @seanpdoyle
+
 ## v0.7.0 / 2026-06-08
 
 ### Security

--- a/lib/active_record/tenanted/global_id.rb
+++ b/lib/active_record/tenanted/global_id.rb
@@ -15,6 +15,10 @@ module ActiveRecord
           gid.model_class.find(gid.model_id)
         end
 
+        def model_class(gid)
+          gid.model_name.constantize
+        end
+
         private
           def ensure_tenant_context_safety(gid)
             model_class = gid.model_class

--- a/test/unit/global_id_test.rb
+++ b/test/unit/global_id_test.rb
@@ -69,6 +69,15 @@ describe ActiveRecord::Tenanted::GlobalId::Locator do
     end
 
     describe "in correct tenanted context" do
+      test "resolves .model_class" do
+        TenantedApplicationRecord.create_tenant("foo") do
+          original_user = User.create!(email: "user1@example.org")
+          model_class = ActiveRecord::Tenanted::GlobalId::Locator.new.model_class(original_user.to_global_id)
+
+          assert_equal(User, model_class)
+        end
+      end
+
       test "loads correctly" do
         TenantedApplicationRecord.create_tenant("foo") do
           original_user = User.create!(email: "user1@example.org")


### PR DESCRIPTION
Resolve deprecation warning related to the new
`GlobalId::Locator#model_class` method introduced by [rails/globalid#203][] and released as part of [v1.4.0][].

This commit introduces the
`ActiveRecord::Tenanted::GlobalId::Locator#model_class` method based on the baseline implementation provided by [rails/globalid#203][] in order to resolve deprecation warnings like the following:

```
DEPRECATION WARNING: Your locator ActiveRecord::Tenanted::GlobalId::Locator does not implement the `model_class` method. Please add a `model_class(gid)` method to your locator or inherit from `GlobalID::Locator::BaseLocator`.
```

[v1.4.0]: https://github.com/rails/globalid/releases
[rails/globalid#203]: https://github.com/rails/globalid/pull/203/changes